### PR TITLE
Build RISC-V images natively with variable docker command

### DIFF
--- a/esp32c3/Dockerfile
+++ b/esp32c3/Dockerfile
@@ -1,0 +1,2 @@
+FROM alpine:edge
+RUN apk add --update build-base gcc-riscv-none-elf newlib-riscv-none-elf && rm -rf /var/cache/apk/*


### PR DESCRIPTION
Hello there,

I have tweaked the makefile to allow for the following changes:

1. Allow overriding the `docker` command with something else, e.g. `podman`
2. Build the image locally (mdashnet/riscv could not be found in my case)
3. Remove the image when calling `make clean`