### PR TITLE
Include system reset function

### DIFF
--- a/esp32c3/mdk.h
+++ b/esp32c3/mdk.h
@@ -120,6 +120,10 @@ static inline void soc_init(void) {
 #endif
 }
 
+static inline void soc_reset() {
+  REG(C3_RTCCNTL)[0] |= BIT(31);  // Set RTC_CNTL_SW_SYS_RST in RTC_CNTL_OPTIONS0_REG
+}
+
 // API GPIO
 
 static inline void gpio_output_enable(int pin, bool enable) {


### PR DESCRIPTION
I added a quick function to reboot the system by setting `RTC_CNTL_SW_SYS_RST` (bit 31) to true of `RTC_CNTL_OPTIONS0_REG` (0th register of `C3_RTCCNTL`)