### PR TITLE
Enable zicsr extension for ESP32-C3

### DIFF
--- a/esp32c3/build.mk
+++ b/esp32c3/build.mk
@@ -4,7 +4,7 @@ MDK         ?= $(realpath $(dir $(lastword $(MAKEFILE_LIST)))/..)
 ESPUTIL     ?= $(MDK)/esputil/esputil
 CFLAGS      ?= -W -Wall -Wextra -Werror -Wundef -Wshadow -pedantic \
                -Wdouble-promotion -fno-common -Wconversion \
-               -march=rv32imc -mabi=ilp32 \
+               -march=rv32imc_zicsr -mabi=ilp32 \
                -Os -ffunction-sections -fdata-sections \
                -I. -I$(MDK)/$(ARCH) $(EXTRA_CFLAGS)
 LINKFLAGS   ?= -T$(MDK)/$(ARCH)/link.ld -nostdlib -nostartfiles -Wl,--gc-sections $(EXTRA_LINKFLAGS)


### PR DESCRIPTION
In the current state, attempting to access a CSR results in a message like
`main.c:13: Error: unrecognized opcode csrr s0,0x7e2, extension zicsr required`.

The ESP32-C3 supports the `_zicsr` extension, which can be enable with the `march` compiler flag.